### PR TITLE
Add a workflow that caches Typst.

### DIFF
--- a/.github/workflows/cache_typst.yaml
+++ b/.github/workflows/cache_typst.yaml
@@ -1,0 +1,55 @@
+# Copyright 2024 Oregon State Flying Club
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build Typst take a few minutes. To keep the actions that run on PRs fast, we
+# cache the Typst binary. Workflows that run on PRs cannot see each others'
+# cache entries, so this workflow runs periodically on the default branch (main)
+# to populate the cache for all branches.
+#
+# If no activity occurs on the repository for 60 days, GitHub will automatically
+# disable this workflow to save resources. I expect that will happen
+# occasionally. The per-PR workflow(s) should re-enable this workflow (and kick
+# off execution) if they experience a cache miss.
+
+name: Cache Typst
+on:
+  # Cache entries are deleted 7 days after their last use. We run this workflow
+  # every 7 days to keep the cache current while minimizing resource usage.
+  # There might be some small gaps between when a cache entry is evicted and
+  # when this is run, so we set this to run at 2am PST to minimize the chance a
+  # PR is opened during those gaps. The choice to run Saturday morning is to
+  # give us two weekend days to fix it if the Typst build breaks.
+  schedule:
+    - cron: '0 10 * * 6'
+  # Also allow for manual execution, which is used by per-PR workflow(s) to kick
+  # off this cache if they experience a cache miss (and is also useful for
+  # testing).
+  workflow_dispatch:
+
+jobs:
+  cache_typst:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Typst
+        run: cargo install typst-cli
+
+      - name: Save Typst Cache
+        uses: actions/cache/save@v4
+        with:
+          # Caches are immutable and cannot be overwritten, so we use the run ID
+          # to make a unique key each time this is executed. The per-PR
+          # workflow(s) can use `restore-keys: typst-` to retrieve the most
+          # recent cache entry.
+          key: typst-${{github.run_id}}
+          path: ~/.cargo/bin/typst


### PR DESCRIPTION
Building Typst takes four minutes. To keep workflows that use Typst fast, this workflow periodically builds Typst and stores it in the GitHub cache for other workflows to use.

I've been working on a workflow (#3) that uses Typst. This workflow will need to be merged to `main` before I can send that workflow as a PR.