### PR TITLE
Add "avionics on" to 73146's start checklist.

### DIFF
--- a/73146.typ
+++ b/73146.typ
@@ -59,6 +59,7 @@
 		([Oil pressure], [CHECK], [If no pressure in 30 seconds, shutdown]),
 		([Mixture], [GROUND LEAN]),
 		checklist_group("Before Taxi"),
+		([Avionics], [ON]),
 		([Headset], [ON]),
 		([Flaps], [RETRACT]),
 		([Weather], [OBTAIN]),


### PR DESCRIPTION
At the last meetup, someone pointed out that there was no "turn the avionics on" step on N73146's start checklist. This PR adds that step.

Note that this step isn't *necessary*, because:

1. It's not listed in the POH checklist.
2. It's somewhat redundant with the "Weather … OBTAIN" checklist item.

It sounds like the consensus is that this is good to have, but I'm open to feedback.