### PR TITLE
Only run the Render Checklists flow on PRs, not pushes to main.

### DIFF
--- a/.github/workflows/render_checklists.yaml
+++ b/.github/workflows/render_checklists.yaml
@@ -19,9 +19,6 @@
 name: Render Checklists
 on:
   pull_request:
-  push:
-    branches:
-      - main
 permissions: {}
 
 jobs:


### PR DESCRIPTION
This was a leftover from when I was developing the render + comment workflows and was testing them on my fork's `main` branch.

It's resulting in failed workflow runs when PRs are merged into `main`, e.g. https://github.com/OpenCorvallis/osfc-checklists/actions/runs/9152653654.