### PR TITLE
Before takeoff: replace flaps up with flaps 0-10°.

### DIFF
--- a/73146.typ
+++ b/73146.typ
@@ -133,7 +133,7 @@
 		([Takeoff briefing], [COMPLETE]),
 		([Beacon, navigation, landing lights], [ON]),
 		([Carburetor heat], [AS REQUIRED]),
-		([Flaps], [UP]),
+		([Flaps], [0-10°]),
 		([Trim], [TAKEOFF]),
 		([Fuel valve], [BOTH]),
 		([Fuel quantity], [CHECK]),


### PR DESCRIPTION
The POH's before takeoff checklist just says `Wing Flaps -- UP`, but the amplified procedures section has two paragraphs on the topic, which discusses short and soft field takeoffs with and without obstacles. This changes the takeoff flaps step to say `0-10°`, and assumes the pilot will determine the appropriate flap setting for their takeoff.

Alternatively, I could put `AS REQUIRED` here.