### PR TITLE
Font option: Linux Libertine.

### DIFF
--- a/73146.typ
+++ b/73146.typ
@@ -323,6 +323,8 @@
 // Page definitions and formatting
 // -----------------------------------------------------------------------------
 
+#set text(font: "Linux Libertine")
+
 // This is set to the minimum margin size that Ryan V's printer can support
 // (experimentally-determined).
 #let margins = 6mm
@@ -359,7 +361,7 @@
 		     align(center, box(fill: white, outset: 1em)[= Emergency Checklists]))
 		#v(-.5em)
 		#columns(2, gutter: 2mm)[
-			#set text(9pt)
+			#set text(9.8pt)
 			#right_emergency_checklists
 		]
 	]


### PR DESCRIPTION
This is the default font Typst has been using; I'm creating this so I have a baseline to compare other font options to.