### PR TITLE
Make recording tach and Hobbs time consistent.

### DIFF
--- a/66083.typ
+++ b/66083.typ
@@ -85,9 +85,9 @@
 		([Flap], [CHECK SECURE, CONDITION]),
 		checklist_group("Final"),
 		([Weight and balance], [CHECKED]),
-		([Baggage door], [LOCK]),
+		([Flight Circle], [DISPATCH]),
 		([Tach, Hobbs times], [RECORD]),
-		([FlightCircle], [DISPATCH]),
+		([Baggage door], [LOCK]),
 		([Chocks], [REMOVE]),
 		([Tie-downs], [REMOVE]),
 	)
@@ -98,7 +98,7 @@
 		([Pitot cover], [APPLY]),
 		([Fuel selector], [LEFT or RIGHT]),
 		([Tach, Hobbs times], [RECORD]),
-		([FlightCircle], [CHECK IN]),
+		([Flight Circle], [CHECK IN]),
 		([Doors], [LOCK]),
 	)
 ]
@@ -468,7 +468,7 @@
 	#columns(2, gutter: 2*margins)[
 		= Ground Checklists #h(1fr) N66083
 		#columns(2)[
-			#set text(9.4pt)
+			#set text(9.5pt)
 			#ground_checklists_and_info
 		]
 		#v(1fr)

--- a/73146.typ
+++ b/73146.typ
@@ -62,7 +62,8 @@
 		([Stall warning], [TEST]),
 		([Aileron], [CHECK], [Freedom of movement and security]),
 		checklist_group("Final"),
-		([FlightCircle], [DISPATCH]),
+		([Flight Circle], [DISPATCH]),
+		([Tach, Hobbs times], [RECORD]),
 		([Baggage door], [LOCK]),
 		([Chocks], [REMOVE]),
 		([Tie-downs], [REMOVE]),
@@ -73,7 +74,7 @@
 		([Vents, windows], [CLOSE]),
 		([Pitot cover], [APPLY]),
 		([Tach, Hobbs times], [RECORD]),
-		([FlightCircle], [CHECK IN]),
+		([Flight Circle], [CHECK IN]),
 		([Doors], [LOCK]),
 	)
 ]
@@ -381,7 +382,7 @@
 		#set text(10pt)
 		= Ground Checklists and Information #h(1fr) N73146
 		#columns(2)[
-			#set text(8.7pt)
+			#set text(8.5pt)
 			#ground_checklists_and_info
 		]
 		#v(1fr)


### PR DESCRIPTION
For both 73146 and 66083, we now have an entry during the cabin section (when power is on) to record the tach time, and a separate entry (right before Flight Circle dispatch) to record them in the aircraft log book. This also corrects FlightCircle -> Flight Circle.

Closes #40 