### PR TITLE
Tweak colors based on print shop results.

### DIFF
--- a/73146.typ
+++ b/73146.typ
@@ -379,7 +379,7 @@
 		table(
 			align: (left + horizon, center, center),
 			columns: (auto, 1fr, auto),
-			fill: (_, row) => (none, silver).at(calc.rem(row, 2)),
+			fill: (_, row) => (none, palette.grey).at(calc.rem(row, 2)),
 			inset: (x: title_inset, y: .3em),
 			stroke: none,
 			[], [], [KIAS],
@@ -412,10 +412,6 @@
 					width: width * width_unit)
 			}
 		}
-		// I'm not sure where I got these color values from. Maybe I sampled
-		// them from the light gun signal table in the PHAK?
-		let green = rgb(5%, 69%, 29%)
-		let red = rgb(93%, 10%, 14%)
 		let solid(color) = signal(color, 5)
 		let blink(a, b) = stack(dir: ltr, signal(a, 1), signal(b, 1),
 			signal(a, 1), signal(b, 1), signal(a, 1))
@@ -423,21 +419,21 @@
 		align(center, table(
 			align: (right + horizon, center + horizon, left + horizon),
 			columns: (1fr, auto, 1fr),
-			fill: (_, row) => (none, silver).at(calc.rem(row, 2)),
+			fill: (_, row) => (none, palette.grey).at(calc.rem(row, 2)),
 			inset: .2em,
 			stroke: none,
 			[*Aircraft on the Ground*], [], [*Aircraft in Flight*],
 			table.hline(stroke: .05em + palette.light_green),
-			[Cleared for takeoff], solid(green), [Cleared to land],
-			[Cleared for taxi], blink(green, none), [Return for landing (to be
-				followed by steady green at the proper time)],
-			[STOP], solid(red),
+			[Cleared for takeoff], solid(palette.lg_green), [Cleared to land],
+			[Cleared for taxi], blink(palette.lg_green, none), [Return for
+				landing (to be followed by steady green at the proper time)],
+			[STOP], solid(palette.lg_red),
 				[Give way to other aircraft and continue circling],
-			[Taxi clear of the runway in use], blink(red, none),
+			[Taxi clear of the runway in use], blink(palette.lg_red, none),
 				[Airport unsafe, do not land],
 			[Return to starting point on airport], blink(white, none),
 				[Not applicable],
-			[Exercise extreme caution], blink(green, red),
+			[Exercise extreme caution], blink(palette.lg_green, palette.lg_red),
 				[Exercise extreme caution],
 		))
 	}

--- a/common.typ
+++ b/common.typ
@@ -20,10 +20,18 @@
 	black: black,
 	brown: rgb("653700"), // XKCD color survey brown
 	dark_blue: rgb("0043df"),
-	dark_green: rgb("6e7500"),
+	dark_green: rgb("6c7500"),
 	light_blue: rgb("009dad"),
 	light_green: green,
-	purple: rgb("8000a0"),
+	purple: rgb("8000a1"),
+
+	// This is the background color for the dark rows of the checklists. This is
+	// not to be used to color the checklist boxes themselves.
+	grey: luma(222),
+
+	// Colors used for the light gun signals portion of the checklist
+	lg_green: rgb("0db04a"),
+	lg_red: rgb("ee1a24"),
 )
 
 //------------------------------------------------------------------------------
@@ -154,7 +162,7 @@
 #let checklist(title, color, emergency: false, ..arguments) = {
 	let steps = arguments.pos();
 	let vars = (
-		bg_colors: (white, silver),
+		bg_colors: (white, palette.grey),
 		// Index of the current background color within `bg_colors`.
 		bg_idx: 0,
 		// The color of the checklist box.


### PR DESCRIPTION
Now that I've printed and laminated checklist samples at the print shop, I took a hard look at the colors. I think the light green could use less red, both to make it more visible under a dim red light and to make it easier to distinguish from the brown.  I also think the purple could use a bit more blue. However, because I don't want to sit at the print shop making tweaks and printing things over-and-over, I decided to make the minimum-possible change so as to avoid accidentally overshooting (because the existing colors are *fine*). I've already tested reducing light_green's red component by 1, so I'm reducing the red by 2 here, and the rest are tweaked by 1 (or just converted to hex RGB and rounded in the direction I want to move them).