### PR TITLE
Tweak colors again based on 146's beta rc2 print samples.

### DIFF
--- a/common.typ
+++ b/common.typ
@@ -20,14 +20,14 @@
 	black: black,
 	brown: rgb("653700"), // XKCD color survey brown
 	dark_blue: rgb("0043df"),
-	dark_green: rgb("6c7500"),
+	dark_green: rgb("6b7500"),
 	light_blue: rgb("009dad"),
 	light_green: green,
 	purple: rgb("8000a1"),
 
 	// This is the background color for the dark rows of the checklists. This is
 	// not to be used to color the checklist boxes themselves.
-	grey: luma(222),
+	grey: luma(221),
 
 	// Colors used for the light gun signals portion of the checklist
 	lg_green: rgb("0db04a"),


### PR DESCRIPTION
I went to the print shop today and printed off more samples, which I labeled `BETA (rc2)`. I think the dark green and grey can be tweaked a bit more; this does that. As before, I'm only changing by 1 to avoid accidentally going too far.