### PR TITLE
Remove the wide gap where the crease is, reduce margins.

### DIFF
--- a/66083.typ
+++ b/66083.typ
@@ -515,13 +515,14 @@
 #set text(fallback: false, font: "DejaVu Sans")
 
 #let heading_size = 10pt
-#let margins = 5mm
+#let margins = 4mm     // Margins around the outer edges of the printed sheet.
+#let crease_gap = 2mm  // Size of the gap that will be cut for the crease.
 #page(flipped: true, margin: margins, paper: "us-letter")[
-	#columns(2, gutter: 2*margins)[
+	#columns(2, gutter: crease_gap)[
 		#set text(heading_size)
 		= Ground Checklists #h(1fr) N66083
 		#columns(2)[
-			#set text(9.5pt)
+			#set text(9.7pt)
 			#ground_checklists_and_info
 		]
 		#v(1fr)
@@ -535,7 +536,7 @@
 	]
 ]
 #page(flipped: true, margin: margins, paper: "us-letter")[
-	#columns(2, gutter: 2*margins)[
+	#columns(2, gutter: crease_gap)[
 		#set text(heading_size)
 		#box(fill: red, width: 100%,
 		     align(center, box(fill: white, outset: 1em)[= Engine Failures]))
@@ -555,7 +556,7 @@
 	]
 ]
 #page(flipped: true, margin: margins, paper: "us-letter")[
-	#columns(2, gutter: 2*margins)[
+	#columns(2, gutter: crease_gap)[
 		#set text(heading_size)
 		#box(fill: red, width: 100%,
 		     align(center, box(fill: white, outset: 1em)[= Electrical Malfunctions]))
@@ -575,13 +576,13 @@
 	]
 ]
 #page(flipped: true, margin: margins, paper: "us-letter")[
-	#columns(2, gutter: 2*margins)[
+	#columns(2, gutter: crease_gap)[
 		#set text(heading_size)
 		#box(fill: red, width: 100%,
 		     align(center, box(fill: white, outset: 1em)[= Fires]))
 		#v(-.5em)
 		#columns(2)[
-			#set text(9pt)
+			#set text(9.9pt)
 			#fires
 		]
 		#colbreak()

--- a/72pe.typ
+++ b/72pe.typ
@@ -178,9 +178,10 @@
 #set text(fallback: false, font: "DejaVu Sans")
 
 #let heading_size = 10pt
-#let margins = 5mm
+#let margins = 4mm     // Margins around the outer edges of the printed sheet.
+#let crease_gap = 2mm  // Size of the gap that will be cut for the crease.
 #page(flipped: true, margin: margins, paper: "us-letter")[
-	#columns(2, gutter: 2*margins)[
+	#columns(2, gutter: crease_gap)[
 		#set text(heading_size)
 		= Ground Checklists and Information #h(1fr) N72PE
 		#columns(2)[
@@ -198,7 +199,7 @@
 	]
 ]
 #page(flipped: true, margin: margins, paper: "us-letter")[
-	#columns(2, gutter: 2*margins)[
+	#columns(2, gutter: crease_gap)[
 		#set text(heading_size)
 		#box(fill: red, width: 100%,
 		     align(center, box(fill: white, outset: 1em)[= Emergency Checklists]))

--- a/73146.typ
+++ b/73146.typ
@@ -183,7 +183,7 @@
 		([Flaps], [20°]),
 		([Airspeed], [60 KIAS]),
 		([Selected field], [FLY OVER], [Note terrain/obstructions.\ Retract
-			flaps upon reaching\ a safe altitude and airspeed.]),
+			flaps upon reaching a\ safe altitude and airspeed.]),
 		([Radios, electrical switches], [OFF]),
 		([Flaps], [40° (on final approach)]),
 		([Airspeed], [60 KIAS]),
@@ -196,7 +196,7 @@
 	#checklist("Ditching", palette.light_blue, emergency: true,
 		([Radio], [MAYDAY on 121.5 MHz], [Give location, intentions]),
 		([Heavy objects], [SECURE or JETTISON]),
-		([Flaps], [20°-40°]),
+		([Flaps], [20° - 40°]),
 		([Power], [300 FT/MIN DESCENT AT 55 KIAS],
 		 [If no power available, approach\ flaps up 65 KIAS or flaps 10° 60 KIAS]),
 		([Strong wind, heavy seas:\ #h(1em)LAND INTO WIND\
@@ -446,15 +446,16 @@
 #set text(fallback: false, font: "DejaVu Sans")
 
 #let heading_base_size = 10pt
-#let margins = 5mm
+#let margins = 4mm     // Margins around the outer edges of the printed sheet.
+#let crease_gap = 2mm  // Size of the gap that will be cut for the crease.
 #page(flipped: true, margin: margins, paper: "us-letter")[
 	// page() supports multiple columns, but does not support setting the gutter
 	// width for multiple columns, so we call columns() ourselves instead.
-	#columns(2, gutter: 2*margins)[
+	#columns(2, gutter: crease_gap)[
 		#set text(heading_base_size)
 		= Ground Checklists and Information #h(1fr) N73146
 		#{
-			set text(8.5pt)
+			set text(8.7pt)
 			columns(2)[
 				#ground_checklists_and_info_columns
 			]
@@ -471,13 +472,13 @@
 	]
 ]
 #page(flipped: true, margin: margins, paper: "us-letter")[
-	#columns(2, gutter: 2*margins)[
+	#columns(2, gutter: crease_gap)[
 		#set text(heading_base_size)
 		#box(fill: red, width: 100%,
 		     align(center, box(fill: white, outset: 1em)[= Engine Failures, Forced Landings]))
 		#v(-.5em)
 		#columns(2, gutter: 2mm)[
-			#set text(8.5pt)
+			#set text(8.9pt)
 			#left_emergency_checklists
 		]
 		#colbreak()
@@ -485,7 +486,7 @@
 		     align(center, box(fill: white, outset: 1em)[= Fires, Icing, Flat Tire, Electrical]))
 		#v(-.5em)
 		#columns(2, gutter: 2mm)[
-			#set text(7.6pt)
+			#set text(7.7pt)
 			#right_emergency_checklists
 		]
 	]


### PR DESCRIPTION
My new home printer can handle narrower margins, and I think the print shop printers can as well. This reduces the margins by 1mm. Also, now that I'm cutting the sheet in two during lamination, I no longer need the design to include margins where the crease will be. This reclaims that space, leaving a gap just wide enough to cut through.

I adjusted font sizes and re-word-smith'd 146's checklist. I did some font size adjustments on 66083 and 2pe as well (though less, because they haven't been wordsmithed yet).