### PR TITLE
Tweak colors further.

### DIFF
--- a/common.typ
+++ b/common.typ
@@ -20,14 +20,14 @@
 	black: black,
 	brown: rgb("653700"), // XKCD color survey brown
 	dark_blue: rgb("0043df"),
-	dark_green: rgb("6b7500"),
+	dark_green: rgb("6a7500"),
 	light_blue: rgb("009dad"),
 	light_green: green,
-	purple: rgb("8000a1"),
+	purple: rgb("8000a2"),
 
 	// This is the background color for the dark rows of the checklists. This is
 	// not to be used to color the checklist boxes themselves.
-	grey: luma(221),
+	grey: luma(223),
 
 	// Colors used for the light gun signals portion of the checklist
 	lg_green: rgb("0db04a"),


### PR DESCRIPTION
I just got back from the print shop with updated samples. This tweaks the colors a bit more. Adjusting by only 1 as I did before to avoid overshooting.

1. Reduce the red component of dark green, to make the white title text more readable (both in good lighting and under a dim red light).
1. Add 1 to the blue component of purple, to make it more different from brown.
1. Brighten gray, as the print shop printers render it quite dark.