### PR TITLE
Produce print-shop PDF with every even page rotated.

### DIFF
--- a/.github/workflows/render_checklists.yaml
+++ b/.github/workflows/render_checklists.yaml
@@ -59,15 +59,12 @@ jobs:
         run: |
           mkdir -p rendered_pr/build
           echo ${{ github.event.number }} > rendered_pr/pr_number
-          echo PR ${{ github.event.number }} > osfc-checklists/signature.typ
-          typst compile osfc-checklists/66083.typ rendered_pr/build/66083.pdf
-          typst compile osfc-checklists/66083.typ rendered_pr/build/66083_{n}.svg
-          typst compile osfc-checklists/72pe.typ rendered_pr/build/72pe.pdf
-          typst compile osfc-checklists/72pe.typ rendered_pr/build/72pe_{n}.svg
-          typst compile osfc-checklists/73146.typ rendered_pr/build/73146.pdf
-          typst compile osfc-checklists/73146.typ rendered_pr/build/73146_{n}.svg
           cd osfc-checklists
           git rev-parse HEAD > ../rendered_pr/git_ref
+          echo PR ${{ github.event.number }} > signature.typ
+          make -j4 normal svgs
+          cp *.pdf ../rendered_pr/build/
+          cp svgs/*.svg ../rendered_pr/build/
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,10 @@
 /66083.pdf
 /72pe.pdf
 /73146.pdf
+/print_shop/66083.pdf
+/print_shop/72pe.pdf
+/print_shop/73146.pdf
 /signature.typ
+/svgs/66083_[1-4].svg
+/svgs/72pe_[1-2].svg
+/svgs/73146_[1-2].svg

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,80 @@
+# Copyright 2025 Oregon State Flying Club
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Makefile produces three sets of output files:
+#
+#   1. The "normal" PDF files.
+#   2. The "print shop" PDF files.
+#   3. SVG images of each page.
+#
+# The normal PDF files are produced by `typst compile <file>`. Use these for
+# manual review and printing at home. This Makefile keeps them in the position
+# that Typst puts them by default (next to the .typ files) so that you can
+# easily mix `make` invocations with manual `typst compile` commands.
+#
+# The print shop PDF files are put into a print_shop/ directory. These files
+# have every even page rotated 180 degrees. This minimizes misalignment during
+# manual double-sided printing (see fabricating.md for more information).
+#
+# The SVG images are placed in the svgs/ directory. There are used by the Post
+# Comment workflow to embed images into PR comments.
+
+# This should be the only thing that needs to change if a checklist is added or
+# removed.
+planes ::= 66083 72pe 73146
+
+# Paths to the normal PDF files.
+normal_pdfs ::= $(foreach plane,$(planes),$(plane).pdf)
+
+# Paths to the print shop PDF files.
+print_shop_pdfs ::= $(foreach plane,$(planes),print_shop/$(plane).pdf)
+
+# The number of SVGs generated varies from checklist to checklist. Rather than
+# telling make exactly which SVGs are generated for each airplane (which would
+# have to be hardcoded and updated manually), we just have one phony target to
+# generate the SVGs for each plane. svg_targets is the list of the SVG target
+# names.
+svg_targets ::= $(foreach plane,$(planes),svgs/$(plane))
+
+# Meta targets that build collections of other targets
+.PHONY: all normal print_shop svgs
+all: normal print_shop svgs
+normal: $(normal_pdfs)
+print_shop: $(print_shop_pdfs)
+svgs: $(svg_targets)
+
+.PHONY: clean
+clean:
+	rm -df $(print_shop_pdfs) \
+		$(foreach plane,$(planes),$(plane).pdf svgs/$(plane)_*.svg) \
+		print_shop/ svgs/
+
+$(normal_pdfs): %.pdf: %.typ
+	typst compile $<
+
+print_shop_dir:
+	mkdir -p print_shop
+
+# qpdf was chosen because it can rotate pages without re-encoding the page (it
+# should only touch the page angle metadata), thereby avoiding quality loss.
+$(print_shop_pdfs): print_shop/%.pdf: %.pdf | print_shop_dir
+	qpdf --rotate=+180:1-z:even $*.pdf $@
+
+svgs_dir:
+	mkdir -p svgs
+
+.PHONY: $(svg_targets)
+$(svg_targets): svgs/%: %.typ | svgs_dir
+	rm -f svgs/$*_*.svg
+	typst compile $< svgs/$*_{p}.svg


### PR DESCRIPTION
The print shop's printers can't do double-sided printing on 100 lb paper. Manually flipping the page results in both sides being misaligned. This change produces PDF files with every other page rotated, which allows us to manually perform double-sided printing without having the sides be misaligned.

The rotation is done using the qpdf tool. qpdf simply updates the rotation angle; it does not re-encode the PDF, so it should not result in quality loss. Note that some PDF readers will not show it correctly, but I've already tested that the print shop printers handle it well.

To make this all automatic, I added a `Makefile`. To simplify the CI environment, I also added support for generating svgs to the Makefile, and adapted the workflow files accordingly.

Closes #61 