### PR TITLE
Submit print jobs online rather than using the customer-use printers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,5 @@
 # limitations under the License.
 
 /73146.pdf
-/print_shop/73146.pdf
 /signature.typ
 /svgs/73146_[1-2].svg

--- a/fabricating.md
+++ b/fabricating.md
@@ -3,22 +3,6 @@
 The checklists are printed and laminated at the FedEx Office Print and Ship
 Center on 9th street in Corvallis.
 
-## Possible future changes
-
-The below process was tested and works in practice. However, the print shop
-informed me that the printer they have behind the counter can do double-sided
-printing on 100lb paper. I plan to try that the next time I make the checklists.
-They gave me a couple pieces of advice:
-
-1. Submit the print job online (through FedEx's website) to avoid extra fees.
-1. The website will indicate a 3-5 hour turnaround, you can ignore that. The
-turnaround is actually 10-15 minutes. It sounds like that's the computer system
-delay, and they'll actually print it when you arrive (I'm not 100% sure though).
-
-Oh, and the shop said they will be getting new printers in a few months. They
-won't be less capable but they're not sure if the new printers will be more
-capable.
-
 ## Overview of the fabricating process
 
 1. Print out the checklists, double-sided.
@@ -28,49 +12,39 @@ capable.
 1. Place a heavy book on top while the lamination cools.
 stapler.
 
-## Paper selection
+## Printing
+
+There is a printer behind the counter (employee use only) that has a much higher
+print quality than the customer-use printers (and which can print double-sided
+on 100lb paper). According to a store employee, it is cheaper to submit print
+jobs online than to give the file to an employee in-store. Therefore, I suggest
+submitting the print job online.
 
 Higher-weight paper is less transparent, which makes it easier to read under
 strong light conditions. However, lamination struggles with high-weight paper.
-The print shop says they can laminate up to 100 lb paper.
+This might result in longevity issues. For now, use the heaviest option (100lb
+matte cover), but if the lamination doesn't last long enough then we should
+reduce to a lighter paper.
 
-The printers can do automatic double-sided printing on up to 80 lb paper. To
-perform double-sided printing on 100 lb paper, we have to print on one side,
-flip the paper manually, then print on the other side. The printers at this shop
-have significant misalignment: they print the contents off to the side by a
-couple millimeters. If you do manual double-sided printing using the normal PDF
-(with pages upright), then this will result in the two sides being misaligned
-with each other, and you won't have the necessary margins around the crease.
-Instead, we use the "print shop" PDF files, which have every even page rotated
-180 degrees. The process is:
+The printing should be double-sided, and the paper size is US Letter. I suggest
+ordering one more copy than you plan to use, as it's easy to make a mistake
+later in the process resulting in a poor-quality checklist.
 
-1. Do a single-sided print of the odd pages in order.
-2. Flip the pages over along their long axis (i.e. perpendicular to the axis the
-crease will be on).
-3. Do a single-sided print of the even pages in order.
+Currently, there's no option to indicate that the double-sided print should be
+flipped along the short edge, nor anywhere to leave a note for the employee
+telling them that. If they get to the print job before you get to the store,
+they might call you to ask which way it should be flipped.
 
-The flip in step two flips the pages over, corrects for the 180 degree rotation
-of the even pages in the PDF, and reverses the order of the pages (so the first
-page is on top), which makes the print work correctly.
-
-The printers are loaded with 20 lb paper. You can purchase the higher-weight
-paper from the front desk. You'll have to use the feeder tray to feed the paper,
-and there are some special procedures to convince it to use the external feed
-slot and to tell it the weight of the paper (ask employees for help if unsure).
-To print on 100 lb paper, use the "Heavy 6" preset (heavy 6 and heavy 7 both
-support 100 lb paper, I asked them which to use).
-
-For now, I am using 100 lb matte paper. If the lamination's longevity becomes an
-issue, then we should reduce to a lighter weight paper (80 pounds or less). In
-that case, we should remove the code that generates the "print shop" PDF files
-and use the printers' automatic double-sided printing, as that is easier and
-aligns the sides better.
+The website will indicate that the turnaround is several hours (or even the next
+day). This is generally inaccurate: they'll likely be able to print it in a few
+minutes if that printer is not busy.
 
 ## Paper cutting
 
 To correct for the printer's misalignment, use the straight cutter to trim off
 excess margins on all sides. Note that you'll have to check both sides to see
-what the margins are because they may be misaligned by 1-2 millimeters.
+what the margins are because they may be misaligned by 1-2 millimeters. Using a
+cell phone flashlight to see through the paper is helpful here.
 
 Then chop each page in two down the center (where the crease will be).
 
@@ -79,7 +53,8 @@ Then chop each page in two down the center (where the crease will be).
 Double-check the laminator is set to 4.5 (that's normally what it's left at).
 Make sure you orient the page in the orientation that will make the fold
 easiest; both to make the fold more expedient and to avoid accidentally folding
-the checklist in the wrong direction.
+the checklist in the wrong direction. For me, this is emergency-side-up (so I
+fold it like I'm closing a book).
 
 Place the two halves of the paper sheet into the plastic, and carefully align
 them. You want about a 1 millimeter gap where the crease will be (experimentally
@@ -87,8 +62,10 @@ determined), and equal margins all the way around. Make sure the center gap is
 perfectly even.
 
 Then feed the sleeve through the laminator. As soon as it stops moving, remove
-it and fold it over (before it cools). Try to fold it evenly. Don't try hard to
-make the crease happen in the correct place: it will automatically crease at the
-1mm gap between the pages (and there's no opportunity to align the corners
-during the folding process). Then place a heavy book on top while the lamination
-cools.
+it and fold it over before it cools. Try to fold it quickly but evenly (as in,
+don't start at the top or the bottom of the crease -- fold the whole page at
+once). Don't try hard to make the crease happen in the correct place: it will
+automatically crease at the 1mm gap between the pages (and there's no
+opportunity to align the corners during the folding process). I've seen the best
+results when the fold is complete within 3 seconds of the laminator stopping.
+Then place a heavy book on top while the lamination cools.


### PR DESCRIPTION
The print shop has a better printer that is best used by submitting print jobs online. This switches the fabrication instructions to use the better printer.

This PR removes everything related to manual double-sided printing, including the Makefile mechanism to generate the "print shop" PDFs, because the better printer can do automatic double-sided printing on 100lb paper.