### PR TITLE
Tweak colors based on the 2025-08-13 print.

### DIFF
--- a/common.typ
+++ b/common.typ
@@ -27,7 +27,7 @@
 
 	// This is the background color for the dark rows of the checklists. This is
 	// not to be used to color the checklist boxes themselves.
-	grey: luma(223),
+	grey: luma(224),
 
 	// Colors used for the light gun signals portion of the checklist
 	lg_green: rgb("0db04a"),


### PR DESCRIPTION
As before, I'm only bumping things by 1 so that I don't accidentally overshoot (this print turned out great). This print was on the employee-use printer, which is what I plan to use moving forward.

The gray backgrounds remained obvious in light levels that were unreadably low, so I brightened them a bit because I believe that will make the text more readable without any adverse effects.

I noticed the purple, light blue, and light green are slightly light under a dim light, but they're still very readable and removing brightness from them would make them harder to distinguish from the dark variants (and brown) so I'm leaving those alone.