### PR TITLE
Start version 3; color tweaks.

### DIFF
--- a/73063.typ
+++ b/73063.typ
@@ -479,7 +479,7 @@
 			light_gun_signals
 			v(1fr)
 		}
-		= Version 2 #h(1fr) #include "signature.typ"
+		= Version 3 #h(1fr) #include "signature.typ"
 		#colbreak()
 		= Operating Checklists #h(1fr) N73063
 		#columns(2)[

--- a/73146.typ
+++ b/73146.typ
@@ -470,7 +470,7 @@
 			light_gun_signals
 			v(1fr)
 		}
-		= Version 2 #h(1fr) #include "signature.typ"
+		= Version 3 #h(1fr) #include "signature.typ"
 		#colbreak()
 		= Operating Checklists #h(1fr) N73146
 		#columns(2)[

--- a/common.typ
+++ b/common.typ
@@ -22,12 +22,12 @@
 	dark_blue: rgb("0043df"),
 	dark_green: rgb("6a7500"),
 	light_blue: rgb("009dad"),
-	light_green: green,
+	light_green: rgb("2ecb40"),
 	purple: rgb("8000a2"),
 
 	// This is the background color for the dark rows of the checklists. This is
 	// not to be used to color the checklist boxes themselves.
-	grey: luma(224),
+	grey: luma(225),
 
 	// Colors used for the light gun signals portion of the checklist
 	lg_green: rgb("0db04a"),


### PR DESCRIPTION
This increases the version number to 3 to prepare for future changes, and tweaks the colors again (based on the version 2 prints).

I bumped the gray stripe brightness up again (to improve text readability). This also darkens the green component of the light_green color by 1 to improve the readability of the checklist headings.